### PR TITLE
Bump version to 0.1.3 to create a tag and use the cookbook in Ubuntu 14 & 16

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@engineyard.com'
 license          'Apache 2.0'
 description      'Installs/Configures libguestfs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 recipe           'libguestfs', 'Installs guestfs libraries and tools'
 recipe           'libguestfs::dev', 'Installs guestfs development libraries'
 recipe           'libguestfs::erlang', 'Installs guestfs erlang bindings'


### PR DESCRIPTION
Version 0.1.2 does not include the last commit, so the cookbook doesn't work in ubuntu 14.04 nor ubuntu 16.04. Please merge this and create a new tag.